### PR TITLE
update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,25 @@
-name: Publish
+name: publish
 
 on:
   release:
     types: [published]
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
-    test:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                node-version: "lts/hydrogen"
-            - run: npm install
-            - run: npm run build
-            - run: npm run test
-
-    publish-npm:
-        needs: test
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                node-version: "lts/hydrogen"
-                registry-url: https://registry.npmjs.org/
-            - run: npm ci
-            - run: npm publish
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/hydrogen"
+          registry-url: https://registry.npmjs.org
+      - name: Update npm
+        run: npm install -g npm@latest
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish


### PR DESCRIPTION
This PR updates the publish workflow to incorporate Github OIDC for new NPM publishing norms:

https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/